### PR TITLE
Introduce <ConfirmationDialog> for all sensitive operations

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -36,7 +36,7 @@ export const ConfigList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/cpuArchitecture.js
+++ b/src/components/cpuArchitecture.js
@@ -21,7 +21,7 @@ export const CpuArchitectureList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/deviceConfigVar.js
+++ b/src/components/deviceConfigVar.js
@@ -54,7 +54,7 @@ export const DeviceConfigVarList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/deviceEnvVar.js
+++ b/src/components/deviceEnvVar.js
@@ -54,7 +54,7 @@ export const DeviceEnvVarList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/deviceFamily.js
+++ b/src/components/deviceFamily.js
@@ -35,7 +35,7 @@ export const DeviceFamilyList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/deviceManufacturer.js
+++ b/src/components/deviceManufacturer.js
@@ -21,7 +21,7 @@ export const DeviceManufacturerList = () => {
         <TextField label='Name' source='name' />
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/deviceServiceVar.js
+++ b/src/components/deviceServiceVar.js
@@ -31,13 +31,10 @@ export const DeviceServiceVarList = () => {
   try {
     const showContext = useShowContext();
 
-    const { data, isLoading, isError } = useGetManyReference (
-      'service install',
-      {
-        target: 'device',
-        id: showContext.record.id
-      }
-    )
+    const { data, isLoading, isError } = useGetManyReference('service install', {
+      target: 'device',
+      id: showContext.record.id,
+    });
 
     const serviceInstallIds = data?.map((x) => x.id) || [];
 
@@ -86,7 +83,7 @@ export const DeviceServiceVarList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/deviceTag.js
+++ b/src/components/deviceTag.js
@@ -54,7 +54,7 @@ export const DeviceTagList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/deviceType.js
+++ b/src/components/deviceType.js
@@ -56,7 +56,7 @@ export const DeviceTypeList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/deviceTypeAlias.js
+++ b/src/components/deviceTypeAlias.js
@@ -29,7 +29,7 @@ export const DeviceTypeAliasList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/fleetConfigVar.js
+++ b/src/components/fleetConfigVar.js
@@ -45,7 +45,7 @@ export const FleetConfigVarList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>
@@ -79,13 +79,17 @@ export const FleetConfigVarCreate = () => {
               <TextInput
                 label='Name'
                 source='name'
-                validate={[required(), unique({
-                  filter: {
-                    application: formData.application,
-                  },
-                  message: uniqueIssueMessage
-                })]}
-                size='large' />
+                validate={[
+                  required(),
+                  unique({
+                    filter: {
+                      application: formData.application,
+                    },
+                    message: uniqueIssueMessage,
+                  }),
+                ]}
+                size='large'
+              />
             )}
           </FormDataConsumer>
           <TextInput label='Value' source='value' validate={required()} size='large' />

--- a/src/components/fleetEnvVar.js
+++ b/src/components/fleetEnvVar.js
@@ -45,7 +45,7 @@ export const FleetEnvVarList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>
@@ -79,13 +79,17 @@ export const FleetEnvVarCreate = () => {
               <TextInput
                 label='Name'
                 source='name'
-                validate={[required(), unique({
-                  filter: {
-                    application: formData.application,
-                  },
-                  message: uniqueIssueMessage
-                })]}
-                size='large' />
+                validate={[
+                  required(),
+                  unique({
+                    filter: {
+                      application: formData.application,
+                    },
+                    message: uniqueIssueMessage,
+                  }),
+                ]}
+                size='large'
+              />
             )}
           </FormDataConsumer>
           <TextInput label='Value' source='value' validate={required()} size='large' />

--- a/src/components/fleetTag.js
+++ b/src/components/fleetTag.js
@@ -45,7 +45,7 @@ export const FleetTagList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>
@@ -80,13 +80,17 @@ export const FleetTagCreate = () => {
               <TextInput
                 label='Name'
                 source='tag key'
-                validate={[required(), unique({
-                  filter: {
-                    application: formData.application,
-                  },
-                  message: uniqueIssueMessage
-                })]}
-                size='large' />
+                validate={[
+                  required(),
+                  unique({
+                    filter: {
+                      application: formData.application,
+                    },
+                    message: uniqueIssueMessage,
+                  }),
+                ]}
+                size='large'
+              />
             )}
           </FormDataConsumer>
           <TextInput label='Value' source='value' validate={required()} size='large' />

--- a/src/components/fleetType.js
+++ b/src/components/fleetType.js
@@ -47,7 +47,7 @@ export const FleetTypeList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/imageEnvVar.js
+++ b/src/components/imageEnvVar.js
@@ -54,7 +54,7 @@ export const ImageEnvVarList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/imageLabel.js
+++ b/src/components/imageLabel.js
@@ -54,7 +54,7 @@ export const ImageLabelList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/organization.js
+++ b/src/components/organization.js
@@ -30,7 +30,7 @@ export const OrganizationList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/permission.js
+++ b/src/components/permission.js
@@ -21,7 +21,7 @@ export const PermissionList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/releaseTag.js
+++ b/src/components/releaseTag.js
@@ -54,7 +54,7 @@ export const ReleaseTagList = (props) => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/role.js
+++ b/src/components/role.js
@@ -22,7 +22,7 @@ export const RoleList = () => {
         <TextField source='name' />
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/serviceEnvVar.js
+++ b/src/components/serviceEnvVar.js
@@ -48,7 +48,7 @@ export const ServiceEnvVarList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/serviceLabel.js
+++ b/src/components/serviceLabel.js
@@ -42,7 +42,7 @@ export const ServiceLabelList = () => {
 
         <Toolbar>
           <EditButton label='' size='small' variant='outlined' />
-          <DeleteButton label='' size='small' variant='outlined' />
+          <DeleteButton mutationMode='optimistic' label='' size='small' variant='outlined' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/components/userKey.js
+++ b/src/components/userKey.js
@@ -37,7 +37,7 @@ export const UserKeysList = () => {
 
         <Toolbar>
           <EditButton label='' variant='outlined' size='small' />
-          <DeleteButton label='' variant='outlined' size='small' />
+          <DeleteButton mutationMode='optimistic' label='' variant='outlined' size='small' />
         </Toolbar>
       </Datagrid>
     </List>

--- a/src/dashboards/device/controlsWidget.js
+++ b/src/dashboards/device/controlsWidget.js
@@ -1,8 +1,8 @@
+import React from 'react';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { Box, Button, CardActions, Typography } from '@mui/material';
-import * as React from 'react';
 import {
   EditButton,
   FunctionField,
@@ -15,6 +15,7 @@ import {
 import { OnlineField } from '../../components/device';
 import utf8decode from '../../lib/utf8decode';
 import environment from '../../lib/reactAppEnv';
+import { ConfirmationDialog } from '../../ui/ConfirmationDialog';
 
 const styles = {
   actionCard: {
@@ -35,6 +36,8 @@ const ControlsWidget = () => {
   const authProvider = useAuthProvider();
   const notify = useNotify();
   const record = useRecordContext();
+
+  const [confirmationDialog, setConfirmationDialog] = React.useState(null);
 
   const invokeSupervisor = (device, command) => {
     const session = authProvider.getSession();
@@ -107,21 +110,37 @@ const ControlsWidget = () => {
                 >
                   Blink
                 </Button>
+
                 <Button
                   variant='outlined'
                   size='medium'
-                  onClick={() => invokeSupervisor(record, 'reboot')}
                   startIcon={<RestartAltIcon />}
                   disabled={isOffline}
+                  onClick={() => {
+                    setConfirmationDialog({
+                      title: 'Reboot Device',
+                      message: 'Are you sure you want to reboot this device?',
+                      confirmText: 'Reboot',
+                      onConfirm: () => invokeSupervisor(record, 'reboot'),
+                    });
+                  }}
                 >
                   Reboot
                 </Button>
+
                 <Button
                   variant='outlined'
                   size='medium'
-                  onClick={() => invokeSupervisor(record, 'shutdown')}
                   startIcon={<PowerSettingsNewIcon />}
                   disabled={isOffline}
+                  onClick={() => {
+                    setConfirmationDialog({
+                      title: 'Shutdown Device',
+                      message: 'Are you sure you want to shut down this device?',
+                      confirmText: 'Shutdown',
+                      onConfirm: () => invokeSupervisor(record, 'shutdown'),
+                    });
+                  }}
                 >
                   Shutdown
                 </Button>
@@ -130,6 +149,10 @@ const ControlsWidget = () => {
           }}
         />
       </CardActions>
+
+      {!!confirmationDialog && (
+        <ConfirmationDialog {...confirmationDialog} onClose={() => setConfirmationDialog(null)} />
+      )}
     </>
   );
 };

--- a/src/dashboards/device/controlsWidget.js
+++ b/src/dashboards/device/controlsWidget.js
@@ -119,8 +119,7 @@ const ControlsWidget = () => {
                   onClick={() => {
                     setConfirmationDialog({
                       title: 'Reboot Device',
-                      message: 'Are you sure you want to reboot this device?',
-                      confirmText: 'Reboot',
+                      content: 'Are you sure you want to reboot this device?',
                       onConfirm: () => invokeSupervisor(record, 'reboot'),
                     });
                   }}
@@ -136,9 +135,7 @@ const ControlsWidget = () => {
                   onClick={() => {
                     setConfirmationDialog({
                       title: 'Shutdown Device',
-                      message: 'Are you sure you want to shut down this device?',
-                      confirmText: 'Shutdown',
-                      destructive: true,
+                      content: 'Are you sure you want to shut down this device?',
                       onConfirm: () => invokeSupervisor(record, 'shutdown'),
                     });
                   }}

--- a/src/dashboards/device/controlsWidget.js
+++ b/src/dashboards/device/controlsWidget.js
@@ -138,6 +138,7 @@ const ControlsWidget = () => {
                       title: 'Shutdown Device',
                       message: 'Are you sure you want to shut down this device?',
                       confirmText: 'Shutdown',
+                      destructive: true,
                       onConfirm: () => invokeSupervisor(record, 'shutdown'),
                     });
                   }}

--- a/src/ui/ConfirmationDialog.js
+++ b/src/ui/ConfirmationDialog.js
@@ -1,0 +1,45 @@
+import { Box, Button, CircularProgress, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import React from 'react';
+
+export const ConfirmationDialog = ({ open = true, title, message, onClose, onConfirm, confirmText, destructive }) => {
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  return (
+    <Dialog open={open} onClose={isLoading ? undefined : onClose}>
+      <DialogTitle>{title}</DialogTitle>
+
+      <DialogContent>
+        {!!message && <p style={{ marginTop: '0' }}>{message}</p>}
+
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginTop: 4,
+          }}
+        >
+          <Button variant='outlined' onClick={onClose} disabled={isLoading}>
+            Cancel
+          </Button>
+
+          <Button
+            variant='contained'
+            color={destructive ? 'error' : 'primary'}
+            disabled={isLoading}
+            onClick={async () => {
+              try {
+                setIsLoading(true);
+                await onConfirm?.();
+              } finally {
+                onClose?.();
+                setIsLoading(false);
+              }
+            }}
+          >
+            {isLoading ? <CircularProgress size={24} sx={{ color: 'white' }} /> : confirmText || 'Confirm'}
+          </Button>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/ui/ConfirmationDialog.js
+++ b/src/ui/ConfirmationDialog.js
@@ -1,7 +1,16 @@
-import { Box, Button, CircularProgress, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
 import React from 'react';
 
-export const ConfirmationDialog = ({ open = true, title, message, onClose, onConfirm, confirmText, destructive }) => {
+export const ConfirmationDialog = ({ open = true, title, content, onClose, onConfirm, confirmButtonText }) => {
   const [isLoading, setIsLoading] = React.useState(false);
 
   return (
@@ -9,37 +18,30 @@ export const ConfirmationDialog = ({ open = true, title, message, onClose, onCon
       <DialogTitle>{title}</DialogTitle>
 
       <DialogContent>
-        {!!message && <p style={{ marginTop: '0' }}>{message}</p>}
+        <DialogContentText>{content}</DialogContentText>
+      </DialogContent>
 
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            marginTop: 4,
+      <DialogActions className='custom'>
+        <Button variant='outlined' onClick={onClose} disabled={isLoading}>
+          Cancel
+        </Button>
+
+        <Button
+          variant='contained'
+          disabled={isLoading}
+          onClick={async () => {
+            try {
+              setIsLoading(true);
+              await onConfirm?.();
+            } finally {
+              onClose?.();
+              setIsLoading(false);
+            }
           }}
         >
-          <Button variant='outlined' onClick={onClose} disabled={isLoading}>
-            Cancel
-          </Button>
-
-          <Button
-            variant='contained'
-            color={destructive ? 'error' : 'primary'}
-            disabled={isLoading}
-            onClick={async () => {
-              try {
-                setIsLoading(true);
-                await onConfirm?.();
-              } finally {
-                onClose?.();
-                setIsLoading(false);
-              }
-            }}
-          >
-            {isLoading ? <CircularProgress size={24} sx={{ color: 'white' }} /> : confirmText || 'Confirm'}
-          </Button>
-        </Box>
-      </DialogContent>
+          {isLoading ? <CircularProgress size={24} sx={{ color: 'white' }} /> : confirmButtonText || 'Confirm'}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/ui/DeleteApiKeyButton.js
+++ b/src/ui/DeleteApiKeyButton.js
@@ -1,9 +1,9 @@
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { Button } from '@mui/material';
 import React from 'react';
 import { useNotify, useRecordContext, useUnselectAll, useRefresh } from 'react-admin';
-import { Form } from 'react-final-form';
 import { useDeleteApiKey, useDeleteApiKeyBulk } from '../lib/apiKey';
+import { ConfirmationDialog } from './ConfirmationDialog';
 
 export const DeleteApiKeyButton = (props) => {
   const [open, setOpen] = React.useState(false);
@@ -41,24 +41,16 @@ export const DeleteApiKeyButton = (props) => {
       >
         <DeleteIcon sx={{ mr: '4px' }} size={props.size} /> {props.children}
       </Button>
-      <Dialog open={open} onClose={() => setOpen(false)} aria-labelledby='form-dialog-title'>
-        <DialogTitle id='form-dialog-title'> Delete API Key(s) </DialogTitle>
-        <DialogContent>
-          Note: this action will be irreversible
-          <br />
-          <br />
-          <Form
-            onSubmit={handleSubmit}
-            render={({ handleSubmit, form, submitting, pristine, values }) => (
-              <form onSubmit={handleSubmit}>
-                <Button variant='contained' color='primary' type='submit' disabled={submitting}>
-                  Confirm Delete
-                </Button>
-              </form>
-            )}
-          />
-        </DialogContent>
-      </Dialog>
+
+      <ConfirmationDialog
+        open={open}
+        title='Delete API Key(s)'
+        message='Note: this action will be irreversible'
+        confirmText='Delete'
+        destructive={true}
+        onConfirm={handleSubmit}
+        onClose={() => setOpen(false)}
+      />
     </>
   );
 };

--- a/src/ui/DeleteApiKeyButton.js
+++ b/src/ui/DeleteApiKeyButton.js
@@ -45,9 +45,7 @@ export const DeleteApiKeyButton = (props) => {
       <ConfirmationDialog
         open={open}
         title='Delete API Key(s)'
-        message='Note: this action will be irreversible'
-        confirmText='Delete'
-        destructive={true}
+        content='Note: this action will be irreversible'
         onConfirm={handleSubmit}
         onClose={() => setOpen(false)}
       />

--- a/src/ui/DeleteDeviceButton.js
+++ b/src/ui/DeleteDeviceButton.js
@@ -47,9 +47,7 @@ export const DeleteDeviceButton = (props) => {
       <ConfirmationDialog
         open={open}
         title='Delete Device(s)'
-        message='Note: this action will be irreversible'
-        confirmText='Delete'
-        destructive={true}
+        content='Note: this action will be irreversible'
         onConfirm={handleSubmit}
         onClose={() => setOpen(false)}
       />

--- a/src/ui/DeleteDeviceButton.js
+++ b/src/ui/DeleteDeviceButton.js
@@ -1,9 +1,9 @@
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Button, Dialog, DialogContent, DialogTitle, Tooltip } from '@mui/material';
+import { Button, Tooltip } from '@mui/material';
 import React from 'react';
 import { useNotify, useRecordContext, useUnselectAll, useRefresh } from 'react-admin';
-import { Form } from 'react-final-form';
 import { useDeleteDevice, useDeleteDeviceBulk } from '../lib/device';
+import { ConfirmationDialog } from './ConfirmationDialog';
 
 export const DeleteDeviceButton = (props) => {
   const [open, setOpen] = React.useState(false);
@@ -44,24 +44,15 @@ export const DeleteDeviceButton = (props) => {
         </Button>
       </Tooltip>
 
-      <Dialog open={open} onClose={() => setOpen(false)} aria-labelledby='form-dialog-title'>
-        <DialogTitle id='form-dialog-title'> Delete Device(s) </DialogTitle>
-        <DialogContent>
-          Note: this action will be irreversible
-          <br />
-          <br />
-          <Form
-            onSubmit={handleSubmit}
-            render={({ handleSubmit, form, submitting, pristine, values }) => (
-              <form onSubmit={handleSubmit}>
-                <Button variant='contained' color='primary' type='submit' disabled={submitting}>
-                  Confirm Delete
-                </Button>
-              </form>
-            )}
-          />
-        </DialogContent>
-      </Dialog>
+      <ConfirmationDialog
+        open={open}
+        title='Delete Device(s)'
+        message='Note: this action will be irreversible'
+        confirmText='Delete'
+        destructive={true}
+        onConfirm={handleSubmit}
+        onClose={() => setOpen(false)}
+      />
     </>
   );
 };

--- a/src/ui/DeleteFleetButton.js
+++ b/src/ui/DeleteFleetButton.js
@@ -1,9 +1,9 @@
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { Button } from '@mui/material';
 import React from 'react';
 import { useNotify, useRecordContext, useRedirect } from 'react-admin';
-import { Form } from 'react-final-form';
 import { useDeleteFleet, useDeleteFleetBulk } from '../lib/fleet';
+import { ConfirmationDialog } from './ConfirmationDialog';
 
 export const DeleteFleetButton = (props) => {
   const [open, setOpen] = React.useState(false);
@@ -35,24 +35,16 @@ export const DeleteFleetButton = (props) => {
       >
         <DeleteIcon sx={{ mr: '4px' }} size={props.size} /> {props.children}
       </Button>
-      <Dialog open={open} onClose={() => setOpen(false)} aria-labelledby='form-dialog-title'>
-        <DialogTitle id='form-dialog-title'> Delete Fleet(s) </DialogTitle>
-        <DialogContent>
-          Note: this action will be irreversible
-          <br />
-          <br />
-          <Form
-            onSubmit={handleSubmit}
-            render={({ handleSubmit, form, submitting, pristine, values }) => (
-              <form onSubmit={handleSubmit}>
-                <Button variant='contained' color='primary' type='submit' disabled={submitting}>
-                  Confirm Delete
-                </Button>
-              </form>
-            )}
-          />
-        </DialogContent>
-      </Dialog>
+
+      <ConfirmationDialog
+        open={open}
+        title='Delete Fleet(s)'
+        message='Note: this action will be irreversible'
+        confirmText='Delete'
+        destructive={true}
+        onConfirm={handleSubmit}
+        onClose={() => setOpen(false)}
+      />
     </>
   );
 };

--- a/src/ui/DeleteFleetButton.js
+++ b/src/ui/DeleteFleetButton.js
@@ -39,9 +39,7 @@ export const DeleteFleetButton = (props) => {
       <ConfirmationDialog
         open={open}
         title='Delete Fleet(s)'
-        message='Note: this action will be irreversible'
-        confirmText='Delete'
-        destructive={true}
+        content='Note: this action will be irreversible'
         onConfirm={handleSubmit}
         onClose={() => setOpen(false)}
       />

--- a/src/ui/DeleteReleaseButton.js
+++ b/src/ui/DeleteReleaseButton.js
@@ -1,11 +1,11 @@
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { Button } from '@mui/material';
 import React from 'react';
 import { useNotify, useRecordContext, useRedirect } from 'react-admin';
-import { Form } from 'react-final-form';
 import { useDeleteRelease, useDeleteReleaseBulk } from '../lib/release';
 import versions from '../versions';
 import environment from '../lib/reactAppEnv';
+import { ConfirmationDialog } from './ConfirmationDialog';
 
 const isPinnedOnRelease = versions.resource('isPinnedOnRelease', environment.REACT_APP_OPEN_BALENA_API_VERSION);
 
@@ -72,24 +72,16 @@ export const DeleteReleaseButton = ({ selectedIds, context, ...props }) => {
       >
         <DeleteIcon sx={{ mr: '4px' }} size={props.size} /> {props.children}
       </Button>
-      <Dialog open={open} onClose={() => setOpen(false)} aria-labelledby='form-dialog-title'>
-        <DialogTitle id='form-dialog-title'> Delete Release(s) </DialogTitle>
-        <DialogContent>
-          Note: this action will be irreversible
-          <br />
-          <br />
-          <Form
-            onSubmit={handleSubmit}
-            render={({ handleSubmit, form, submitting, pristine, values }) => (
-              <form onSubmit={handleSubmit}>
-                <Button variant='contained' color='primary' type='submit' disabled={submitting}>
-                  Confirm Delete
-                </Button>
-              </form>
-            )}
-          />
-        </DialogContent>
-      </Dialog>
+
+      <ConfirmationDialog
+        open={open}
+        title='Delete Release(s)'
+        message='Note: this action will be irreversible'
+        confirmText='Delete'
+        destructive={true}
+        onConfirm={handleSubmit}
+        onClose={() => setOpen(false)}
+      />
     </>
   );
 };

--- a/src/ui/DeleteReleaseButton.js
+++ b/src/ui/DeleteReleaseButton.js
@@ -76,9 +76,7 @@ export const DeleteReleaseButton = ({ selectedIds, context, ...props }) => {
       <ConfirmationDialog
         open={open}
         title='Delete Release(s)'
-        message='Note: this action will be irreversible'
-        confirmText='Delete'
-        destructive={true}
+        content='Note: this action will be irreversible'
         onConfirm={handleSubmit}
         onClose={() => setOpen(false)}
       />

--- a/src/ui/DeleteUserButton.js
+++ b/src/ui/DeleteUserButton.js
@@ -39,9 +39,7 @@ export const DeleteUserButton = (props) => {
       <ConfirmationDialog
         open={open}
         title='Delete User(s)'
-        message='Note: this action will be irreversible'
-        confirmText='Delete'
-        destructive={true}
+        content='Note: this action will be irreversible'
         onConfirm={handleSubmit}
         onClose={() => setOpen(false)}
       />

--- a/src/ui/DeleteUserButton.js
+++ b/src/ui/DeleteUserButton.js
@@ -1,9 +1,9 @@
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { Button } from '@mui/material';
 import React from 'react';
 import { useNotify, useRecordContext, useRedirect } from 'react-admin';
-import { Form } from 'react-final-form';
 import { useDeleteUser, useDeleteUserBulk } from '../lib/user';
+import { ConfirmationDialog } from './ConfirmationDialog';
 
 export const DeleteUserButton = (props) => {
   const [open, setOpen] = React.useState(false);
@@ -35,24 +35,16 @@ export const DeleteUserButton = (props) => {
       >
         <DeleteIcon sx={{ mr: '4px' }} size={props.size} /> {props.children}
       </Button>
-      <Dialog open={open} onClose={() => setOpen(false)} aria-labelledby='form-dialog-title'>
-        <DialogTitle id='form-dialog-title'> Delete User(s) </DialogTitle>
-        <DialogContent>
-          Note: this action will be irreversible
-          <br />
-          <br />
-          <Form
-            onSubmit={handleSubmit}
-            render={({ handleSubmit, form, submitting, pristine, values }) => (
-              <form onSubmit={handleSubmit}>
-                <Button variant='contained' color='primary' type='submit' disabled={submitting}>
-                  Confirm Delete
-                </Button>
-              </form>
-            )}
-          />
-        </DialogContent>
-      </Dialog>
+
+      <ConfirmationDialog
+        open={open}
+        title='Delete User(s)'
+        message='Note: this action will be irreversible'
+        confirmText='Delete'
+        destructive={true}
+        onConfirm={handleSubmit}
+        onClose={() => setOpen(false)}
+      />
     </>
   );
 };

--- a/src/ui/customTheme.js
+++ b/src/ui/customTheme.js
@@ -550,6 +550,47 @@ const customTheme = createTheme({
         },
       },
     },
+
+    MuiDialogContent: {
+      styleOverrides: {
+        root: {
+          padding: '0 24px',
+        },
+      },
+    },
+
+    MuiDialogActions: {
+      styleOverrides: {
+        root: {
+          'display': 'flex',
+          'justifyContent': 'space-between',
+          'padding': '30px 24px 20px',
+
+          '&:not(.custom)': {
+            '.MuiButton-root': {
+              '&.MuiButton-containedPrimary': {
+                color: 'white',
+              },
+
+              '&:first-of-type': {
+                'background': 'none',
+                'border': `1px solid ${theme.palette.primary.light}`,
+                'color': theme.palette.primary.main,
+
+                '&:hover': {
+                  background: 'rgba(42, 80, 111, 0.04)',
+                  border: `1px solid ${theme.palette.primary.main}`,
+                },
+              },
+
+              '.MuiButton-icon': {
+                display: 'none',
+              },
+            },
+          },
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
We’ve got a new component just for confirmation dialogs. You can customize it with options like title, content, confirmButtonText, and callbacks. If your onConfirm callback is a promise, it’ll wait for it to finish while showing a spinner.

<img width="1027" alt="Captura de Tela 2025-04-11 às 10 42 03" src="https://github.com/user-attachments/assets/d41fd7b9-3f0a-4e60-bb5d-94349b3bb8d3" />

<img width="1031" alt="Captura de Tela 2025-04-11 às 10 43 25" src="https://github.com/user-attachments/assets/d1a90294-5991-47ab-abb4-74e292d0a1cd" />
