### PR TITLE
Use `is online`/`is connected to vpn` for device status and gate supervisor actions on VPN

### DIFF
--- a/src/components/device.tsx
+++ b/src/components/device.tsx
@@ -55,21 +55,29 @@ export const OnlineField: React.FC<Omit<FunctionFieldProps<any>, 'render'>> = (p
   return (
     <FunctionField
       {...props}
-      render={(record, source) => {
-        if (!source) {
-          return null;
-        }
-        const isOnline = record[source] === 'online';
+      render={(record) => {
+        const isOnline = record['is online'] === true;
+        const vpnConnected = record['is connected to vpn'] === true;
+        const color = !isOnline
+          ? theme.palette.error.light // red
+          : vpnConnected
+            ? theme.palette.success.light // green
+            : theme.palette.warning.light; // orange
+        const status = `${isOnline ? 'Online' : 'Offline'}, ${vpnConnected ? 'VPN connected' : 'no VPN connection'}`;
+        const lastEvent = record['last connectivity event'];
+        const title = lastEvent ? (
+          <>
+            {status}
+            <br />
+            (since {dateFormat(new Date(lastEvent))})
+          </>
+        ) : (
+          status
+        );
 
         return (
-          <Tooltip
-            placement='top'
-            arrow={true}
-            title={'Since ' + dateFormat(new Date(record['last connectivity event']))}
-          >
-            <strong style={{ color: isOnline ? theme.palette.success.light : theme.palette.error.light }}>
-              {isOnline ? 'Online' : 'Offline'}
-            </strong>
+          <Tooltip placement='top' arrow={true} title={title}>
+            <strong style={{ color }}>{isOnline ? 'Online' : 'Offline'}</strong>
           </Tooltip>
         );
       }}
@@ -133,7 +141,7 @@ const ReleaseFieldContent: React.FC<{
       : false;
 
   const isUpToDate = hasTarget ? isTargetMatch : isTrackingLatest;
-  const isOnline = record['api heartbeat state'] === 'online';
+  const isOnline = record['is online'] === true;
   const chipIcon = isUpToDate && hasTarget ? <TargetReleaseIcon origin={origin} fontSize='small' /> : undefined;
 
   return (
@@ -203,7 +211,7 @@ export const DeviceList: React.FC<ListProps<any>> = (props) => {
           <TextField source='device name' />
         </ReferenceField>
 
-        <OnlineField label='Status' source='api heartbeat state' />
+        <OnlineField label='Status' />
 
         <ReleaseField label='Current Release' source='is running-release' />
 

--- a/src/dashboards/device/controlsWidget.tsx
+++ b/src/dashboards/device/controlsWidget.tsx
@@ -37,6 +37,8 @@ type DeviceRecord = RaRecord & {
   'uuid': string;
   'device name': string;
   'api heartbeat state'?: string;
+  'is online'?: boolean;
+  'is connected to vpn'?: boolean;
 };
 
 const ControlsWidget: React.FC = () => {
@@ -110,14 +112,14 @@ const ControlsWidget: React.FC = () => {
 
         <p style={{ margin: 0 }}>
           <b>Status: </b>
-          <OnlineField source='api heartbeat state' />
+          <OnlineField />
         </p>
       </Box>
 
       <CardActions sx={styles.actionCard}>
         <FunctionField
           render={(fieldRecord: DeviceRecord) => {
-            const isOffline = fieldRecord['api heartbeat state'] !== 'online';
+            const vpnDisconnected = fieldRecord['is connected to vpn'] !== true;
 
             return (
               <>
@@ -128,7 +130,7 @@ const ControlsWidget: React.FC = () => {
                   size='medium'
                   onClick={() => invokeSupervisor(fieldRecord, 'blink')}
                   startIcon={<LightModeIcon />}
-                  disabled={isOffline}
+                  disabled={vpnDisconnected}
                 >
                   Blink
                 </Button>
@@ -137,7 +139,7 @@ const ControlsWidget: React.FC = () => {
                   variant='outlined'
                   size='medium'
                   startIcon={<RestartAltIcon />}
-                  disabled={isOffline}
+                  disabled={vpnDisconnected}
                   onClick={() => {
                     setConfirmationDialog({
                       title: 'Reboot Device',
@@ -153,7 +155,7 @@ const ControlsWidget: React.FC = () => {
                   variant='outlined'
                   size='medium'
                   startIcon={<PowerSettingsNewIcon />}
-                  disabled={isOffline}
+                  disabled={vpnDisconnected}
                   onClick={() => {
                     setConfirmationDialog({
                       title: 'Shutdown Device',

--- a/src/dashboards/main/devices.tsx
+++ b/src/dashboards/main/devices.tsx
@@ -111,7 +111,7 @@ export const DeviceCards: React.FC = () => (
                             <TableRow>
                               <TableCell sx={{ fontWeight: 'bold' }}>Status</TableCell>
                               <TableCell align='right'>
-                                <OnlineField record={record} source='api heartbeat state' />
+                                <OnlineField record={record} />
                               </TableCell>
                             </TableRow>
                             <TableRow>

--- a/src/dashboards/main/fleets.tsx
+++ b/src/dashboards/main/fleets.tsx
@@ -142,7 +142,7 @@ export const FleetCards: React.FC = () => (
                                   source='id'
                                   reference='device'
                                   target='belongs to-application'
-                                  filter={{ 'api heartbeat state': 'online' }}
+                                  filter={{ 'is online': true }}
                                 />{' '}
                                 /{' '}
                                 <ReferenceManyCount


### PR DESCRIPTION
Addresses #106.

### Summary
Derives device online status from the native `is online` flag instead of the `api heartbeat state` enum, and gates the supervisor actions on VPN connectivity.

### Changes
- **`OnlineField`** is now a three-state indicator from `is online` + `is connected to vpn`:
  - Green: online + VPN
  - Orange: online / no VPN
  - Red: offline

  Label stays "Online"/"Offline"; tooltip  carries the full state and the "since `last connectivity event`" time.
- **`ReleaseField`** icon and the **fleet "online / total"** count now key off `is online`.
- **Controls widget** gates Blink/Reboot/Shutdown on `is connected to vpn` instead of  heartbeat. Those commands are relayed to the device over the VPN tunnel, so an online but VPN-disconnected device would otherwise fail silently. Edit stays ungated.

No data-layer changes (the PostgREST provider already returns all device columns).

### Testing
`npm run typecheck` passes; verified manually against an open-balena backend (status colors/tooltips, fleet count, and VPN-gated actions).