### PR TITLE
fix: repository links and enhance compatibility section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     name: Push to Docker Hub
     runs-on: ubuntu-latest
     needs: build-docker
-    if: ${{ !startsWith(github.ref, 'refs/pull/') }}
+    if: ${{ github.repository == 'ob-community/open-balena-ui' && !startsWith(github.ref, 'refs/pull/') }}
     permissions:
       contents: write
     steps:
@@ -138,16 +138,22 @@ jobs:
           tags: ${{ steps.vtl.outputs.docker_tags }}
           labels: ${{ steps.vtl.outputs.oci_labels }}
 
-      - name: Update package.json version
+      - name: Update package version
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           VERSION="${{ steps.vtl.outputs.ver_tag }}"
-          VERSION_NO_V="${VERSION#v}"
-          jq --arg v "$VERSION_NO_V" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+          npm version "${VERSION#v}" --no-git-tag-version
 
-      - name: Commit updated package.json
+      - name: Commit updated package version
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add -f package.json
-          git commit -m "chore: update package.json version [skip CI]"
-          git push origin HEAD
+          git add -f package.json package-lock.json
+
+          if git diff --cached --quiet; then
+            echo "Package version is already up to date"
+          else
+            git commit -m "chore: update package version [skip CI]"
+            git push origin HEAD
+          fi

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # User Interface for Open Balena Admin
 
-User interface for [open-balena-admin](https://github.com/dcaputo-harmoni/open-balena-admin), an admin interface for
+User interface for [open-balena-admin](https://github.com/ob-community/open-balena-admin), an admin interface for
 open-balena.
 
 ## Dependencies
 
-This project is dependent on [open-balena-postgrest](https://github.com/dcaputo-harmoni/open-balena-postgrest) and
-[open-balena-remote](https://github.com/dcaputo-harmoni/open-balena-remote), so the easiest way to get this up and
-running would be to install it via the [open-balena-admin](https://github.com/dcaputo-harmoni/open-balena-admin)
+This project is dependent on [open-balena-postgrest](https://github.com/ob-community/open-balena-postgrest) and
+[open-balena-remote](https://github.com/ob-community/open-balena-remote), so the easiest way to get this up and
+running would be to install it via the [open-balena-admin](https://github.com/ob-community/open-balena-admin)
 project.
 
 ## Configuration
@@ -83,9 +83,437 @@ convention.
 
 ## Compatibility
 
-This project is compatible with `open-balena-api` v0.139.0 or newer, all the way up to the current builds (v0.190.0).
-See [this project](https://github.com/dcaputo-harmoni/open-balena-helm) for a fork of bartversluijs' open-balena-helm
-project which has helm scripts to build a current version of `open-balena`.
+`open-balena-ui` supports `open-balena-api` **v0.139.0 and newer**.
+
+Maintaining compatibility across this range requires more than checking the API generation exposed at `/v6` or `/v7`. The `open-balena-api` data model has evolved substantially over time, and fields, relationships, and their semantics are sometimes added, renamed, migrated, or removed without changing the API generation.
+
+For that reason, `open-balena-ui` maintains a version compatibility layer in `src/versions/index.ts`.
+
+### `REACT_APP_OPEN_BALENA_API_VERSION`
+
+`REACT_APP_OPEN_BALENA_API_VERSION` **must contain the tagged semver release of the `open-balena-api` server being used**, for example:
+
+```text
+REACT_APP_OPEN_BALENA_API_VERSION=v25.2.8
+```
+
+or:
+
+```text
+REACT_APP_OPEN_BALENA_API_VERSION=v45.0.0
+```
+
+The leading `v` is optional for the compatibility resolver.
+
+This value is **not** the API generation from the URL.
+
+For example:
+
+```text
+v45.0.0       # open-balena-api package/release version - correct
+45.0.0        # also accepted - correct
+
+v7            # API generation - incorrect
+v6            # API generation - incorrect
+```
+
+The `/v6` and `/v7` API generations describe revisions of the external API contract. They are not sufficiently granular for UI compatibility decisions. `open-balena-api` frequently changes its SBVR model, generated resources, fields, or field semantics while continuing to expose the same `/v7` API generation.
+
+The value supplied to `REACT_APP_OPEN_BALENA_API_VERSION` should therefore correspond to the actual `open-balena-api` release/tag used by the deployment, such as the API container image version or the version reported by the `open-balena-api` package.
+
+This distinction is important. For example, both `open-balena-api` v25 and v45 expose API v7, but they require different compatibility behavior in `open-balena-ui`.
+
+### How version compatibility works
+
+`src/versions/index.ts` provides semantic aliases for API resources and fields whose underlying SBVR names have changed over the lifetime of `open-balena-api`.
+
+Application code should refer to the semantic alias rather than independently deciding which API field name to use.
+
+For example:
+
+```ts
+const isPinnedOnRelease = versions.resource(
+  'isPinnedOnRelease',
+  environment.REACT_APP_OPEN_BALENA_API_VERSION,
+);
+```
+
+and:
+
+```ts
+const deviceOnlineStatus = versions.field(
+  'deviceOnlineStatus',
+  environment.REACT_APP_OPEN_BALENA_API_VERSION,
+);
+```
+
+The mappings in `src/versions/index.ts` are keyed by the specific `open-balena-api` semver release where a compatibility boundary occurs.
+
+They are **change points**, not a list of every supported API version.
+
+For example, given mappings at:
+
+```text
+0.185.0
+25.2.8
+45.0.0
+```
+
+a deployment running `open-balena-api` v25.0.6 selects the `0.185.0` compatibility map, because that is the newest known compatibility boundary less than or equal to v25.0.6.
+
+A deployment running v25.2.8 selects the `25.2.8` map.
+
+A deployment running v44.3.0 also selects the `25.2.8` map.
+
+A deployment running v45.0.0 or a later release selects the `45.0.0` map.
+
+Internally, the resolver finds the greatest mapped semver that is less than or equal to `REACT_APP_OPEN_BALENA_API_VERSION`. Each new mapping inherits the previous mapping and overrides only the resources or fields that changed.
+
+For example:
+
+```ts
+versions['45.0.0'] = {
+  resources: {
+    ...versions['25.2.8'].resources,
+  },
+  fields: {
+    ...versions['25.2.8'].fields,
+    deviceOnlineStatus: 'is connected to vpn',
+  },
+  translations: {
+    ...versions['25.2.8'].translations,
+  },
+};
+```
+
+There is therefore no need to add entries for v25.2.9, v26, v30, v44, etc. unless one of those versions introduces another API difference that `open-balena-ui` needs to account for.
+
+If a requested semantic key has no explicit mapping, `versions.resource()` or `versions.field()` returns the supplied key unchanged.
+
+If `REACT_APP_OPEN_BALENA_API_VERSION` is omitted, or no configured compatibility boundary is less than or equal to the supplied version, the current resolver falls back to the newest known compatibility map. Because of this behavior, deployments should always configure the actual supported `open-balena-api` version. Versions older than v0.139.0 are outside the supported compatibility range.
+
+### Currently tracked compatibility boundaries
+
+The compatibility map currently tracks the following `open-balena-api` change points. Each entry inherits all mappings from the preceding entry.
+
+| `open-balena-api` version | Compatibility change introduced at this boundary                                                                                                                              |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **v0.139.0**              | Oldest supported API version. `isPinnedOnRelease` resolves to the legacy device relation `should be running-release`. `deviceOnlineStatus` resolves to `api heartbeat state`. |
+| **v0.149.0**              | Adds mappings for release finalization, semantic-version components, revision, final status, and semver.                                                                      |
+| **v0.157.3**              | Adds `applicationIsOfClass` → `is of-class`.                                                                                                                                  |
+| **v0.158.0**              | Adds `releaseKnownIssueList` → `known issue list`.                                                                                                                            |
+| **v0.170.0**              | Adds `releaseNote` → `note`.                                                                                                                                                  |
+| **v0.171.0**              | Adds `releaseInvalidationReason` → `invalidation reason`.                                                                                                                     |
+| **v0.185.0**              | Adds `deviceTypeAlias` → `device type alias`.                                                                                                                                 |
+| **v25.2.8**               | Changes `isPinnedOnRelease` from the legacy `should be running-release` relation to `is pinned on-release`.                                                                   |
+| **v45.0.0**               | Changes the UI's semantic `deviceOnlineStatus` field from `api heartbeat state` to `is connected to vpn`.                                                                     |
+
+The complete baseline for the two compatibility aliases that span the largest API ranges is therefore:
+
+```ts
+'0.139.0': {
+  resources: {
+    isPinnedOnRelease: 'should be running-release',
+  },
+  fields: {
+    deviceOnlineStatus: 'api heartbeat state',
+  },
+  translations: {},
+},
+```
+
+with the later overrides:
+
+```ts
+versions['25.2.8'] = {
+  resources: {
+    ...versions['0.185.0'].resources,
+    isPinnedOnRelease: 'is pinned on-release',
+  },
+  fields: {
+    ...versions['0.185.0'].fields,
+  },
+  translations: {
+    ...versions['0.185.0'].translations,
+  },
+};
+
+versions['45.0.0'] = {
+  resources: {
+    ...versions['25.2.8'].resources,
+  },
+  fields: {
+    ...versions['25.2.8'].fields,
+    deviceOnlineStatus: 'is connected to vpn',
+  },
+  translations: {
+    ...versions['25.2.8'].translations,
+  },
+};
+```
+
+### Device release pinning compatibility
+
+Device release pinning is an example of why the compatibility layer is based on `open-balena-api` release versions rather than API generations.
+
+Older versions of the API exposed the device target/pinning relationship through:
+
+```text
+should be running-release
+```
+
+The newer explicit pinning relationship is:
+
+```text
+is pinned on-release
+```
+
+The migration inside `open-balena-api` happened in several stages:
+
+| Version     | Pinning migration                                                                                                                        |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **v23.3.0** | Added `is pinned on-release` and synchronized it with the legacy relationship.                                                           |
+| **v25.2.0** | Changed the API's read/source-of-truth behavior to use the new pin relationship while retaining compatibility with the old storage path. |
+| **v25.2.8** | Stopped setting the legacy `should_be_running__release` value and removed the old fact from the SBVR model.                              |
+| **v26.0.1** | Added cleanup to drop the old database column if it still existed.                                                                       |
+
+For `open-balena-ui`, **v25.2.8 is the compatibility boundary** because it is the first release where the legacy relation can no longer be relied upon.
+
+Consequently:
+
+```text
+open-balena-api v0.139.0 through v25.2.7
+    isPinnedOnRelease
+    → "should be running-release"
+
+open-balena-api v25.2.8 and newer
+    isPinnedOnRelease
+    → "is pinned on-release"
+```
+
+Application code should therefore use:
+
+```ts
+const isPinnedOnRelease = versions.resource(
+  'isPinnedOnRelease',
+  environment.REACT_APP_OPEN_BALENA_API_VERSION,
+);
+```
+
+and then use `isPinnedOnRelease` directly as the `source`, record key, query field, or mutation field as appropriate.
+
+Compatibility code should **not** transform device or fleet JSON records back and forth between the old and new field names. The purpose of `versions.resource()` is to make that transformation unnecessary.
+
+For example, prefer:
+
+```tsx
+<ReferenceInput
+  source={isPinnedOnRelease}
+  reference='release'
+  target='id'
+>
+```
+
+rather than creating a `transformDevice()` or `transformFleet()` function that deletes one SBVR property and manufactures another.
+
+This keeps the object returned by the API in its native schema and confines version-specific knowledge to `src/versions/index.ts`.
+
+Also note that:
+
+```text
+application should track latest release
+```
+
+is a separate application-level fact. It should not be confused with the device-level migration from `should be running-release` to `is pinned on-release`.
+
+### Device connectivity and online-status compatibility
+
+`open-balena-api` v45.0.0 introduced another important compatibility boundary.
+
+Before v45, API/UI logic traditionally used heartbeat/online state when deciding whether a device should be treated as online. Beginning with v45.0.0, `open-balena-api` changed the canonical connectivity signal used by `device.overall_status` from `is online` to:
+
+```text
+is connected to vpn
+```
+
+This was **not a schema rename**.
+
+Fields such as:
+
+```text
+api heartbeat state
+is online
+is connected to vpn
+last connectivity event
+last vpn event
+```
+
+exist independently. The v45 change was a change in the meaning of the canonical connectivity state, not the removal of `api heartbeat state`.
+
+For `open-balena-ui`, a semantic compatibility alias is therefore used:
+
+```ts
+deviceOnlineStatus
+```
+
+which resolves as:
+
+```text
+open-balena-api v0.139.0 through v44.x
+    deviceOnlineStatus
+    → "api heartbeat state"
+
+open-balena-api v45.0.0 and newer
+    deviceOnlineStatus
+    → "is connected to vpn"
+```
+
+This is particularly important for structured filters.
+
+Instead of hard-coding either:
+
+```ts
+'api heartbeat state@eq'
+```
+
+or:
+
+```ts
+'is connected to vpn@eq'
+```
+
+the filter should resolve the semantic field first:
+
+```ts
+const deviceOnlineStatus = versions.field(
+  'deviceOnlineStatus',
+  environment.REACT_APP_OPEN_BALENA_API_VERSION,
+);
+
+const deviceOnlineStatusFilter = `${deviceOnlineStatus}@eq`;
+```
+
+and use it in the list of structured filter keys:
+
+```ts
+const STRUCTURED_FILTER_KEYS = [
+  deviceOnlineStatusFilter,
+  'is of-device type@eq',
+  'belongs to-application@eq',
+  'is running-release@in',
+  'os version@ilike',
+] as const;
+```
+
+This matters not only when applying a filter, but also when replacing or removing structured filters. A UI connected to a pre-v45 API must remove:
+
+```text
+api heartbeat state@eq
+```
+
+while a UI connected to v45 or newer must remove:
+
+```text
+is connected to vpn@eq
+```
+
+Hard-coding both field names into `STRUCTURED_FILTER_KEYS` is not equivalent: the configured API version should determine which field represents the semantic "online status" for that deployment.
+
+#### Connectivity filter values
+
+The v45 compatibility change also changes the **type and meaning of the filter value**, so resolving the field name alone is not sufficient.
+
+Before v45, `api heartbeat state` is a state value. For example:
+
+```text
+api heartbeat state = "online"
+api heartbeat state = "offline"
+```
+
+The raw field may also contain other states such as `timeout` or `unknown`.
+
+From v45 onward, the UI's canonical connectivity filter uses the boolean VPN relation:
+
+```text
+is connected to vpn = true
+is connected to vpn = false
+```
+
+Therefore a UI-level filter state such as:
+
+```ts
+'online' | 'offline' | 'all'
+```
+
+must be serialized differently according to the resolved compatibility field.
+
+Conceptually:
+
+```ts
+const usesVpnConnectivity =
+  deviceOnlineStatus === 'is connected to vpn';
+
+listFilters[deviceOnlineStatusFilter] = usesVpnConnectivity
+  ? filters.onlineStatus === 'online'
+  : filters.onlineStatus;
+```
+
+Similarly, when converting a react-admin filter back into the structured UI state, pre-v45 code interprets string heartbeat states while v45+ code interprets boolean VPN connectivity.
+
+The version map is responsible for selecting the **field name**. Code using that field remains responsible for handling differences in the field's **value semantics**.
+
+### Resource and field aliases should be used throughout the UI
+
+When an API concept already has an entry in `src/versions/index.ts`, components should use that entry consistently.
+
+Do not duplicate version tests such as:
+
+```ts
+if (apiVersion >= ...) {
+  // use one SBVR field
+} else {
+  // use another SBVR field
+}
+```
+
+throughout components.
+
+Likewise, do not normalize API objects by deleting old properties and adding new properties merely to make newer UI code work against older API versions.
+
+Instead, resolve the API-specific name once:
+
+```ts
+const isPinnedOnRelease = versions.resource(
+  'isPinnedOnRelease',
+  environment.REACT_APP_OPEN_BALENA_API_VERSION,
+);
+
+const deviceOnlineStatus = versions.field(
+  'deviceOnlineStatus',
+  environment.REACT_APP_OPEN_BALENA_API_VERSION,
+);
+```
+
+and use those resolved names wherever the corresponding concept is accessed.
+
+This provides one source of truth for API-version differences and prevents different parts of the UI from making different assumptions about the same API release.
+
+### Adding compatibility for future API changes
+
+When a newer `open-balena-api` release changes a resource, field, or the semantics the UI depends on:
+
+1. Determine the **exact tagged `open-balena-api` release** where the relevant change becomes applicable. Do not use the `/v6` or `/v7` API generation as the compatibility boundary.
+2. Inspect the `open-balena-api` commit history, changelog, SBVR model, and migrations as necessary. API migrations are often staged across several releases, so distinguish between when a new field is introduced, when it becomes authoritative, and when the old field is actually removed.
+3. Add a semantic alias to the oldest supported mapping if the UI needs to refer to the concept across the entire supported version range.
+4. Add a new version entry at the appropriate change point, inheriting the preceding `resources`, `fields`, and `translations` maps and overriding only the values that changed.
+5. Access the concept through `versions.resource()` or `versions.field()` throughout the UI rather than introducing component-specific version checks or rewriting API records.
+6. If the change also alters the type or meaning of the value—as with heartbeat strings versus VPN booleans—handle that conversion at the point where the value is interpreted or serialized. A field-name mapping by itself does not perform value conversion.
+7. Preserve compatibility with the existing v0.139.0 minimum unless the project's documented minimum supported `open-balena-api` version is intentionally changed.
+
+A new mapping should be added only when the UI needs different behavior starting with that particular `open-balena-api` release.
+
+The compatibility layer is intended to allow the current `open-balena-ui` codebase to operate against both older supported OpenBalena installations and current `open-balena-api` releases without scattering version-specific SBVR knowledge throughout the application.
+
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-balena-ui",
-  "version": "0.7.2",
+  "version": "compatibility-updates",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-balena-ui",
-  "version": "compatibility-updates",
+  "version": "0.7.2",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/src/versions/index.ts
+++ b/src/versions/index.ts
@@ -11,10 +11,15 @@ const versions: Record<string, VersionMapping> = {
     resources: {
       isPinnedOnRelease: 'should be running-release',
     },
-    fields: {},
+    fields: {
+      // Before API v45, the UI's "online" filter is based on
+      // the device heartbeat state.
+      deviceOnlineStatus: 'api heartbeat state',
+    },
     translations: {},
   },
 };
+
 versions['0.149.0'] = {
   resources: {
     ...versions['0.139.0'].resources,
@@ -33,6 +38,7 @@ versions['0.149.0'] = {
     ...versions['0.139.0'].translations,
   },
 };
+
 versions['0.157.3'] = {
   resources: {
     ...versions['0.149.0'].resources,
@@ -101,6 +107,9 @@ versions['0.185.0'] = {
 versions['25.2.8'] = {
   resources: {
     ...versions['0.185.0'].resources,
+
+    // v25.2.8 removes the old writable
+    // device.should_be_running__release relationship.
     isPinnedOnRelease: 'is pinned on-release',
   },
   fields: {
@@ -108,6 +117,22 @@ versions['25.2.8'] = {
   },
   translations: {
     ...versions['0.185.0'].translations,
+  },
+};
+
+versions['45.0.0'] = {
+  resources: {
+    ...versions['25.2.8'].resources,
+  },
+  fields: {
+    ...versions['25.2.8'].fields,
+
+    // v45 switches the canonical connectivity/online semantics
+    // from the heartbeat-based state to VPN connectivity.
+    deviceOnlineStatus: 'is connected to vpn',
+  },
+  translations: {
+    ...versions['25.2.8'].translations,
   },
 };
 


### PR DESCRIPTION
This PR grew out of the compatibility work and review around #110. I did a deeper pass through the `open-balena-api` history to document how `open-balena-ui`'s version abstraction is intended to work and to establish the compatibility boundaries we currently need.

## Compatibility/version handling

The most important clarification is that `REACT_APP_OPEN_BALENA_API_VERSION` is intended to contain the actual tagged `open-balena-api` semver release, such as `v25.2.8` or `v45.0.0`. It is **not** the API-generation identifier such as `/v6` or `/v7`.

That distinction matters because substantial SBVR/model changes have occurred while the API continued to expose `/v7`.

`src/versions/index.ts` is intended to describe **compatibility change-points**, rather than contain an entry for every API release. The resolver selects the greatest mapped semver less than or equal to the configured API version, and each new map inherits the previous map and overrides only the resources/fields that changed.

The API history currently gives us two particularly important long-term compatibility boundaries:

### Device release pinning — `v25.2.8`

- Older APIs use the device relation `should be running-release`.
- `is pinned on-release` was initially introduced in `v23.3.0` and synchronized with the old relation during the migration.
- `v25.2.0` moved API read/source-of-truth behavior to the newer pinning relationship.
- `v25.2.8` is the compatibility boundary used by the UI because that is where the old writable `device.should_be_running__release` relationship was stopped/removed from the SBVR model.
- Therefore `isPinnedOnRelease` resolves to `should be running-release` before `v25.2.8` and `is pinned on-release` from `v25.2.8` onward.
- This should be handled by `versions.resource()` rather than by transforming API records between old and new property names.

### Device online/connectivity state — `v45.0.0`

- Prior to v45, the UI's online filter semantics are based on `api heartbeat state`, with values such as `online` and `offline`.
- In v45, `open-balena-api` switched its canonical `device.overall_status` connectivity signal from the old online state to `is connected to vpn`.
- This is a semantic compatibility change rather than a literal schema rename: `api heartbeat state`, `is online`, `is connected to vpn`, `last connectivity event`, and `last vpn event` remain distinct fields.
- A new semantic field alias, `deviceOnlineStatus`, is therefore defined as `api heartbeat state` in the baseline map and overridden to `is connected to vpn` at `v45.0.0`.
- Consumers such as `DeviceStructuredFilter` can resolve the appropriate field with `versions.field('deviceOnlineStatus', ...)` and construct `${deviceOnlineStatus}@eq` rather than hard-coding one API generation's field name.
- The caller still needs to handle the value-shape difference: pre-v45 heartbeat filtering uses strings (`online` / `offline`), while v45+ VPN filtering uses booleans (`true` / `false`). `versions.field()` intentionally resolves field names; it does not transform field values.

I also reviewed the `open-balena-api` SBVR/model changes after `v25.2.8` through the current releases. There are a number of additive fields/resources in that range—update-status fields, additional timestamps, profile resources, etc.—but they are not old-name/new-name substitutions and therefore do not belong in the current `versions.field()` / `versions.resource()` alias maps.

If we eventually need to support features that exist only after a particular API release, that should probably be represented separately as capability/feature detection rather than overloading the name-alias mechanism.

The README now documents this behavior in detail, including:

- the currently tracked version boundaries;
- how fallback/version selection works;
- the staged pinning migration;
- the v45 connectivity change; and
- guidelines for adding future compatibility mappings.

## Repository links

The README links have also been updated to point at the maintained `ob-community` repositories for `open-balena-admin`, `open-balena-postgrest`, and `open-balena-remote`.

## CI/package versioning

While working on this branch, CI exposed another issue: the package-version update at the end of `push-to-docker-hub` was running for branch pushes as well as `main`.

The Docker publishing job intentionally runs for non-PR branch pushes so that branches in the canonical repository can receive prerelease/branch Docker images. Updating `package.json`, however, is only intended to happen after a push to the canonical repository's `main` branch.

The workflow now reflects those separate concerns:

- `push-to-docker-hub` is restricted to the canonical `ob-community/open-balena-ui` repository in addition to excluding PR refs. This prevents a copy of the workflow running in somebody else's fork from entering our Docker publishing job.
- Branch pushes in `ob-community/open-balena-ui` can still publish the branch/prerelease Docker tags produced by `action-vtl`.
- `package.json` / `package-lock.json` version updates run only for a `push` where `github.ref == 'refs/heads/main'`.
- Because those steps are nested inside the canonical-repository-only Docker publishing job, the effective requirement is: **push + `ob-community/open-balena-ui` + `main`**.
- `npm version ... --no-git-tag-version` is used so both `package.json` and `package-lock.json` remain synchronized.
- The commit step checks whether the version files actually changed before attempting to create a commit, avoiding a CI failure on an empty commit.
- The package-version change accidentally committed to this feature branch by the previous workflow behavior has been reverted.

The intended CI behavior after these changes is:

| Context | Build/test | Docker build | Docker Hub publish | Commit package version |
| --- | --- | --- | --- | --- |
| PR in canonical repo | Yes | Yes | No | No |
| Branch push in canonical repo | Yes | Yes | Yes, branch/prerelease tags | No |
| Push to canonical `main` | Yes | Yes | Yes, release/latest tags as determined by VTL | Yes |
| Fork/external repository | Normal GitHub checks as applicable | No access to our publishing path | No | No |

This PR is primarily establishing/documenting the compatibility contract and adding the v45 semantic field mapping.

The actual structured-filter consumer changes from #110 should use that abstraction rather than hard-coding `is connected to vpn@eq`, so older supported `open-balena-api` installations continue to use `api heartbeat state@eq` correctly.